### PR TITLE
Add explicit `any` types for `mergeWith` and `mergeWithKey`.

### DIFF
--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -804,9 +804,9 @@ declare module R {
         * The key will be excluded from the returned object if the
         * resulting value is undefined.
         */
-        mergeWith: CurriedFunction3<(l, r) => any, any, any, any>;
+        mergeWith: CurriedFunction3<(l:any, r:any) => any, any, any, any>;
 
-        mergeWithKey: CurriedFunction3<(k, l, r) => any, any, any, any>;
+        mergeWithKey: CurriedFunction3<(k:any, l:any, r:any) => any, any, any, any>;
 
         /**
          * Returns a partial copy of an object omitting the keys specified.


### PR DESCRIPTION
This is required to prevent compiler errors when using the `noImplicitAny` compiler flag.

When using that flag with these definitions, you would have gotten the following errors:

```
typings/main/definitions/ramda/ramda.d.ts(388,38): error TS7006: Parameter 'l' implicitly has an 'any' type.
typings/main/definitions/ramda/ramda.d.ts(388,41): error TS7006: Parameter 'r' implicitly has an 'any' type.
typings/main/definitions/ramda/ramda.d.ts(390,41): error TS7006: Parameter 'k' implicitly has an 'any' type.
typings/main/definitions/ramda/ramda.d.ts(390,44): error TS7006: Parameter 'l' implicitly has an 'any' type.
typings/main/definitions/ramda/ramda.d.ts(390,47): error TS7006: Parameter 'r' implicitly has an 'any' type.
```

This change explicitly types those arguments as `any` to prevent this.
